### PR TITLE
Update wording to match the documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,14 +24,13 @@ $urlSet->configure(array(
   'successUrl'      => 'https://www.demoshop.com/sv/success',
   'failureUrl'      => 'https://www.demoshop.com/sv/failure',
   'notificationUrl' => 'https://www.demoshop.com/sv/notify',
-  'pendingUrl'      => 'https://www.demoshop.com/sv/pending',
 ));
 
 $address = new Address;
 $address->configure(array(
   'streetAddress'   => 'Test street 1',
   'postalCode'      => '12345',
-  'postOffice'      => 'Helsinki',
+  'postalOffice'    => 'Helsinki',
   'countryCode'     => 'FI',
 ));
 
@@ -57,7 +56,7 @@ $product = new Product;
 $product->configure(array(
   'title'           => 'Test product',
   'code'            => '01234',
-  'quantity'        => 1.00,
+  'amount'          => 1.00,
   'price'           => 19.90,
   'vat'             => 23.00,
   'discount'        => 0.00,

--- a/src/Object/Address.php
+++ b/src/Object/Address.php
@@ -33,7 +33,7 @@ class Address extends DataObject
     /**
      * @var string $postOffice
      */
-    protected $postOffice;
+    protected $postalOffice;
 
     /**
      * @var string $countryCode
@@ -48,7 +48,7 @@ class Address extends DataObject
         return array(
             'street'       => $this->streetAddress,
             'postalCode'   => $this->postalCode,
-            'postalOffice' => $this->postOffice,
+            'postalOffice' => $this->postalOffice,
             'country'      => $this->countryCode,
         );
     }
@@ -74,13 +74,13 @@ class Address extends DataObject
     }
 
     /**
-     * Get post office.
+     * Get postal office.
      *
      * @return string The post office.
      */
-    public function getPostOffice()
+    public function getPostalOffice()
     {
-        return $this->postOffice;
+        return $this->postalOffice;
     }
 
     /**

--- a/tests/unit/ClientTest.php
+++ b/tests/unit/ClientTest.php
@@ -150,7 +150,7 @@ class ClientTest extends \Codeception\TestCase\Test
         $address->configure(array(
             'streetAddress' => 'Test street 1',
             'postalCode'    => '12345',
-            'postOffice'    => 'Helsinki',
+            'postalOffice'    => 'Helsinki',
             'countryCode'   => 'FI',
         ));
 

--- a/tests/unit/ClientTest.php
+++ b/tests/unit/ClientTest.php
@@ -133,7 +133,6 @@ class ClientTest extends \Codeception\TestCase\Test
             'successUrl'      => 'https://www.demoshop.com/sv/success',
             'failureUrl'      => 'https://www.demoshop.com/sv/failure',
             'notificationUrl' => 'https://www.demoshop.com/sv/notify',
-            'pendingUrl'      => 'https://www.demoshop.com/sv/pending',
         ));
 
         return $urlSet;


### PR DESCRIPTION
Mostly got annoyed when the wording differs from that of the official documentation because it is not imminently clear that `postOffice` will be automatically converted to `postalOffice`. I don't care which is linguistically better but please go with the one that's already used in the official documentation.

Also there was a random `quantity` field left on the readme that's supposed to be `amount`.

~~**DISCLAIMER:** I haven't run any tests on the changes but I'm expecting breakage.~~ Nevermind, there's a Travis CI runner set.